### PR TITLE
more Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO ?= env CGO_ENABLED=0 $(shell command -v go 2> /dev/null)
+GO ?= $(shell command -v go 2> /dev/null)
 DEP ?= $(shell command -v dep 2> /dev/null)
 NPM ?= $(shell command -v npm 2> /dev/null)
 MANIFEST_FILE ?= plugin.json

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,10 @@
-GO=go
-MANIFEST_FILE=plugin.json
+GO ?= $(shell command -v go 2> /dev/null)
+DEP ?= $(shell command -v dep 2> /dev/null)
+NPM ?= $(shell command -v npm 2> /dev/null)
+MANIFEST_FILE ?= plugin.json
 
-# Ensure that the build tools are compiled. Go's caching makes this quick.
-$(shell cd build/manifest && $(GO) build -o ../bin/manifest)
-
-# Extract the plugin id from the manifest.
-PLUGIN_ID=$(shell build/bin/manifest plugin_id)
-ifeq ($(PLUGIN_ID),)
-    $(error Cannot parse id from $(MANIFEST_FILE))
-endif
-
-# Determine if a server is defined in the manifest
-HAS_SERVER=$(shell build/bin/manifest has_server)
-
-# Determine if a webapp is defined in the manifest
-HAS_WEBAPP=$(shell build/bin/manifest has_webapp)
+# Verify environment, and define PLUGIN_ID, HAS_SERVER and HAS_WEBAPP as needed.
+include build/setup.mk
 
 # all, the default target, tests, builds and bundles the plugin.
 all: test dist
@@ -24,10 +14,10 @@ all: test dist
 apply:
 	./build/bin/manifest apply
 
-# vendor ensures the server dependencies are installed
+# server/.depensure ensures the server dependencies are installed
 server/.depensure:
 ifneq ($(HAS_SERVER),)
-	cd server && dep ensure
+	cd server && $(DEP) ensure
 	touch $@
 endif
 
@@ -44,7 +34,7 @@ endif
 # webapp/.npminstall ensures NPM dependencies are installed without having to run this all the time
 webapp/.npminstall:
 ifneq ($(HAS_WEBAPP),)
-	cd webapp && npm install
+	cd webapp && $(NPM) install
 	touch $@
 endif
 
@@ -52,7 +42,7 @@ endif
 .PHONY: webapp
 webapp: webapp/.npminstall
 ifneq ($(HAS_WEBAPP),)
-	cd webapp && npm run build;
+	cd webapp && $(NPM) run build;
 endif
 
 # bundle generates a tar bundle of the plugin for install
@@ -103,12 +93,12 @@ endif
 
 # test runs any lints and unit tests defined for the server and webapp, if they exist
 .PHONY: test
-test: webapp/.npminstall
+test: server/.depensure webapp/.npminstall
 ifneq ($(HAS_SERVER),)
 	cd server && $(GO) test -v -coverprofile=coverage.txt ./...
 endif
 ifneq ($(HAS_WEBAPP),)
-	cd webapp && npm run fix;
+	cd webapp && $(NPM) run fix;
 endif
 
 # clean removes all build artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO ?= $(shell command -v go 2> /dev/null)
+GO ?= env CGO_ENABLED=0 $(shell command -v go 2> /dev/null)
 DEP ?= $(shell command -v dep 2> /dev/null)
 NPM ?= $(shell command -v npm 2> /dev/null)
 MANIFEST_FILE ?= plugin.json
@@ -73,7 +73,7 @@ dist: apply \
 # deploy installs the plugin to a (development) server, using the API if appropriate environment
 # variables are defined, or copying the files directly to a sibling mattermost-server directory
 .PHONY: deploy
-deploy:
+deploy: dist
 ifneq ($(and $(MM_SERVICESETTINGS_SITEURL),$(MM_ADMIN_USERNAME),$(MM_ADMIN_PASSWORD)),)
 	@echo "Installing plugin via API"
 	http --print b --check-status $(MM_SERVICESETTINGS_SITEURL)/api/v4/users/me || ( \

--- a/build/setup.mk
+++ b/build/setup.mk
@@ -1,0 +1,42 @@
+# Ensure that go is installed. Note that this is independent of whether or not a server is being
+# built, since the build script itself uses go.
+ifeq ($(GO),)
+    $(error "go is not available: see https://golang.org/doc/install")
+endif
+
+# Ensure that the build tools are compiled. Go's caching makes this quick.
+$(shell cd build/manifest && $(GO) build -o ../bin/manifest)
+
+# Extract the plugin id from the manifest.
+PLUGIN_ID ?= $(shell build/bin/manifest plugin_id)
+ifeq ($(PLUGIN_ID),)
+    $(error "Cannot parse id from $(MANIFEST_FILE)")
+endif
+
+# Determine if a server is defined in the manifest.
+HAS_SERVER ?= $(shell build/bin/manifest has_server)
+
+# Determine if a webapp is defined in the manifest.
+HAS_WEBAPP ?= $(shell build/bin/manifest has_webapp)
+
+# Try looking for dep in $(GOPATH) in case $(GOPATH)/bin isn't in $(PATH).
+GOPATH ?= $(shell $(GO) env GOPATH)
+ifeq ($(DEP),)
+ifneq ($(wildcard $(GOPATH)/bin/dep),)
+    DEP = $(GOPATH)/bin/dep
+endif
+endif
+
+# Ensure that dep is installed.
+ifneq ($(HAS_SERVER),)
+ifeq ($(DEP),)
+    $(error "dep is not available: see https://golang.github.io/dep/docs/installation.html")
+endif
+endif
+
+# Ensure that npm (and thus node) is installed.
+ifneq ($(HAS_WEBAPP),)
+ifeq ($(NPM),)
+    $(error "npm is not available: see https://www.npmjs.com/get-npm")
+endif
+endif


### PR DESCRIPTION
A few more improvements that make the initial startup experience a bit better:
* warn upfront if go/dep/npm not available
* try to find dep in $GOPATH/bin if not installed globally
* only override variables if not externally defined, allowing manual override from commandline
* split up Makefile into a buid/setup.mk for simplicity

I started out here trying to fix Linux-specific issues, but didn't actually find anything that made this Makefile not-linux specific -- tested on Debian with the standard make installed. Can I get you to give this a shot on your machine to verify?