### PR TITLE
tweak plugin id/version injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ NPM ?= $(shell command -v npm 2> /dev/null)
 HTTP ?= $(shell command -v http 2> /dev/null)
 CURL ?= $(shell command -v curl 2> /dev/null)
 MANIFEST_FILE ?= plugin.json
-BUNDLE_NAME = $(PLUGIN_ID)_$(PLUGIN_VERSION).tar.gz
 
-# Verify environment, and define PLUGIN_ID, HAS_SERVER and HAS_WEBAPP as needed.
+# Verify environment, and define PLUGIN_ID, PLUGIN_VERSION, HAS_SERVER and HAS_WEBAPP as needed.
 include build/setup.mk
+
+BUNDLE_NAME ?= $(PLUGIN_ID)-$(PLUGIN_VERSION).tar.gz
 
 # all, the default target, tests, builds and bundles the plugin.
 all: test dist

--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -21,10 +21,8 @@ var manifest = struct {
 }
 `
 
-const pluginIdJsFileTemplate = `export default {
-    id: '%s',
-    version: '%s',
-};
+const pluginIdJsFileTemplate = `export const id = '%s';
+export const version = '%s';
 `
 
 func main() {

--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -10,15 +10,20 @@ import (
 	"github.com/pkg/errors"
 )
 
-const PluginIdGoFileTemplate = `package main
+const pluginIdGoFileTemplate = `package main
 
-const PluginId = "%s"
-const PluginVersion = "%s"
+var manifest = struct {
+	Id      string
+	Version string
+}{
+	Id:      "%s",
+	Version: "%s",
+}
 `
 
-const PluginIdJsFileTemplate = `export default {
-    PluginId: '%s',
-    PluginVersion: '%s',
+const pluginIdJsFileTemplate = `export default {
+    id: '%s',
+    version: '%s',
 };
 `
 
@@ -98,7 +103,7 @@ func applyManifest(manifest *model.Manifest) error {
 	if manifest.HasServer() {
 		if err := ioutil.WriteFile(
 			"server/manifest.go",
-			[]byte(fmt.Sprintf(PluginIdGoFileTemplate, manifest.Id, manifest.Version)),
+			[]byte(fmt.Sprintf(pluginIdGoFileTemplate, manifest.Id, manifest.Version)),
 			0644,
 		); err != nil {
 			return errors.Wrap(err, "failed to write server/manifest.go")
@@ -108,7 +113,7 @@ func applyManifest(manifest *model.Manifest) error {
 	if manifest.HasWebapp() {
 		if err := ioutil.WriteFile(
 			"webapp/src/manifest.js",
-			[]byte(fmt.Sprintf(PluginIdJsFileTemplate, manifest.Id, manifest.Version)),
+			[]byte(fmt.Sprintf(pluginIdJsFileTemplate, manifest.Id, manifest.Version)),
 			0644,
 		); err != nil {
 			return errors.Wrap(err, "failed to open webapp/src/manifest.js")

--- a/build/setup.mk
+++ b/build/setup.mk
@@ -16,7 +16,7 @@ endif
 # Extract the plugin version from the manifest.
 PLUGIN_VERSION ?= $(shell build/bin/manifest version)
 ifeq ($(PLUGIN_VERSION),)
-    $(error "Cannot parse id from $(MANIFEST_FILE)")
+    $(error "Cannot parse version from $(MANIFEST_FILE)")
 endif
 
 # Determine if a server is defined in the manifest.

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -1,4 +1,9 @@
 package main
 
-const PluginId = "com.mattermost.sample-plugin"
-const PluginVersion = "0.0.1"
+var manifest = struct {
+	Id      string
+	Version string
+}{
+	Id:      "com.mattermost.sample-plugin",
+	Version: "0.0.1",
+}

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -1,4 +1,4 @@
-import Manifest from './manifest';
+import {id as pluginId} from './manifest';
 
 export default class Plugin {
     // eslint-disable-next-line no-unused-vars
@@ -7,4 +7,4 @@ export default class Plugin {
     }
 }
 
-window.registerPlugin(Manifest.PluginId, new Plugin());
+window.registerPlugin(pluginId, new Plugin());

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,4 +1,4 @@
 export default {
-    PluginId: 'com.mattermost.sample-plugin',
-    PluginVersion: '0.0.1',
+    id: 'com.mattermost.sample-plugin',
+    version: '0.0.1',
 };

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,4 +1,2 @@
-export default {
-    id: 'com.mattermost.sample-plugin',
-    version: '0.0.1',
-};
+export const id = 'com.mattermost.sample-plugin';
+export const version = '0.0.1';


### PR DESCRIPTION
* define BUNDLE_NAME after including build/setup.mk (just for clarity, not correctness)
* separate plugin id from version with dash in bundle name to match Mattermost package
* fix various js/go idioms (some pre-existing!)
* fix error message