### PR TITLE
Add make help target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,14 @@ include build/setup.mk
 
 BUNDLE_NAME ?= $(PLUGIN_ID)-$(PLUGIN_VERSION).tar.gz
 
-# all, the default target, tests, builds and bundles the plugin.
-all: check-style test dist
+all: check-style test dist ## Checks the code style, tests, builds and bundles the plugin.
 
-# apply propagates the plugin id into the server/ and webapp/ folders as required.
 .PHONY: apply
-apply:
+apply: ## Propagates plugin manifest information into the server/ and webapp/ folders as required.
 	./build/bin/manifest apply
 
 .PHONY: check-style
-check-style: server/.depensure webapp/.npminstall gofmt govet
+check-style: server/.depensure webapp/.npminstall gofmt govet ## Runs govet and gofmt against all packages.
 	@echo Checking for style guide compliance
 
 ifneq ($(HAS_WEBAPP),)
@@ -27,7 +25,7 @@ ifneq ($(HAS_WEBAPP),)
 endif
 
 .PHONY: gofmt
-gofmt:
+gofmt: ## Runs gofmt against all packages.
 ifneq ($(HAS_SERVER),)
 	@echo Running gofmt
 	@for package in $$(go list ./server/...); do \
@@ -46,23 +44,21 @@ ifneq ($(HAS_SERVER),)
 endif
 
 .PHONY: govet
-govet:
+govet: ## Runs govet against all packages.
 ifneq ($(HAS_SERVER),)
 	@echo Running govet
 	@$(GO) vet $$(go list ./server/...) || exit 1
 	@echo Govet success
 endif
 
-# server/.depensure ensures the server dependencies are installed
-server/.depensure:
+server/.depensure: ## Ensures the server dependencies are installed.
 ifneq ($(HAS_SERVER),)
 	cd server && $(DEP) ensure
 	touch $@
 endif
 
-# server builds the server, if it exists, including support for multiple architectures
 .PHONY: server
-server: server/.depensure
+server: server/.depensure ## Builds the server, if it exists, including support for multiple architectures.
 ifneq ($(HAS_SERVER),)
 	mkdir -p server/dist;
 	cd server && env GOOS=linux GOARCH=amd64 $(GO) build -o dist/plugin-linux-amd64;
@@ -70,23 +66,20 @@ ifneq ($(HAS_SERVER),)
 	cd server && env GOOS=windows GOARCH=amd64 $(GO) build -o dist/plugin-windows-amd64.exe;
 endif
 
-# webapp/.npminstall ensures NPM dependencies are installed without having to run this all the time
-webapp/.npminstall:
+webapp/.npminstall: ## Ensures NPM dependencies are installed without having to run this all the time.
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) install
 	touch $@
 endif
 
-# webapp builds the webapp, if it exists
 .PHONY: webapp
-webapp: webapp/.npminstall
+webapp: webapp/.npminstall ## Builds the webapp, if it exists.
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run build;
 endif
 
-# bundle generates a tar bundle of the plugin for install
 .PHONY: bundle
-bundle:
+bundle: ## Generates a tar bundle of the plugin for install.
 	rm -rf dist/
 	mkdir -p dist/$(PLUGIN_ID)
 	cp $(MANIFEST_FILE) dist/$(PLUGIN_ID)/
@@ -102,17 +95,13 @@ endif
 
 	@echo plugin built at: dist/$(BUNDLE_NAME)
 
-# dist builds and bundles the plugin
 .PHONY: dist
-dist: apply \
-      server \
-      webapp \
-      bundle
+dist:	apply server webapp bundle ## Builds and bundles the plugin.
 
-# deploy installs the plugin to a (development) server, using the API if appropriate environment
-# variables are defined, or copying the files directly to a sibling mattermost-server directory
 .PHONY: deploy
-deploy: dist
+deploy: dist ## Installs the plugin to a (development) server.
+## It uses the API if appropriate environment variables are defined,
+## or copying the files directly to a sibling mattermost-server directory.
 ifneq ($(and $(MM_SERVICESETTINGS_SITEURL),$(MM_ADMIN_USERNAME),$(MM_ADMIN_PASSWORD),$(HTTP)),)
 	@echo "Installing plugin via API"
 		(TOKEN=`http --print h POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/users/login login_id=$(MM_ADMIN_USERNAME) password=$(MM_ADMIN_PASSWORD) | grep Token | cut -f2 -d' '` && \
@@ -137,9 +126,8 @@ else
 	@echo "No supported deployment method available. Install plugin manually."
 endif
 
-# test runs any lints and unit tests defined for the server and webapp, if they exist
 .PHONY: test
-test: server/.depensure webapp/.npminstall
+test: server/.depensure webapp/.npminstall ## Runs any lints and unit tests defined for the server and webapp, if they exist.
 ifneq ($(HAS_SERVER),)
 	cd server && $(GO) test -race -v -coverprofile=coverage.txt ./...
 endif
@@ -147,9 +135,8 @@ ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run fix;
 endif
 
-# clean removes all build artifacts
 .PHONY: clean
-clean:
+clean: ## Clean removes all build artifacts.
 	rm -fr dist/
 ifneq ($(HAS_SERVER),)
 	rm -fr server/dist
@@ -161,3 +148,7 @@ ifneq ($(HAS_WEBAPP),)
 	rm -fr webapp/node_modules
 endif
 	rm -fr build/bin/
+
+ ## Help documentatin à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+help:
+	@grep -E '^[a-zA-Z_-.]+:.*?## .*$$' ./Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
This PR adds a `make help` target similar to the one on the Mattermost server. See https://github.com/mattermost/mattermost-server/blob/master/Makefile#L534.

The current list looks like this:
```
$ make help
all                            Checks the code style, tests, builds and bundles the plugin.
apply                          Propagates plugin manifest information into the server/ and webapp/ folders as required.
bundle                         Generates a tar bundle of the plugin for install.
check-style                    Runs govet and gofmt against all packages.
clean                          Clean removes all build artifacts.
deploy                         Installs the plugin to a (development) server.
dist                           Builds and bundles the plugin.
gofmt                          Runs gofmt against all packages.
govet                          Runs govet against all packages.
server/.depensure              Ensures the server dependencies are installed.
server                         Builds the server, if it exists, including support for multiple architectures.
test                           Runs any lints and unit tests defined for the server and webapp, if they exist.
webapp/.npminstall             Ensures NPM dependencies are installed without having to run this all the time.
webapp                         Builds the webapp, if it exists.
```