### PR TITLE
configuration: ignore an empty configuration struct in setConfiguration

### DIFF
--- a/server/configuration.go
+++ b/server/configuration.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"reflect"
+
 	"github.com/pkg/errors"
 )
 
@@ -53,6 +55,13 @@ func (p *Plugin) setConfiguration(configuration *configuration) {
 	defer p.configurationLock.Unlock()
 
 	if configuration != nil && p.configuration == configuration {
+		// Ignore assignment if the configuration struct is empty. Go will optimize the
+		// allocation for same to point at the same memory address, breaking the check
+		// above.
+		if reflect.ValueOf(*configuration).NumField() == 0 {
+			return
+		}
+
 		panic("setConfiguration called with the existing configuration")
 	}
 


### PR DESCRIPTION
If the plugin leaves the configuration struct empty, go will optimize away allocations of the zero-width struct, failing the `setConfiguration` check that prevents a user from introducing race conditions.

The demo plugin has more extensive unit tests around configuration, but it also has a non-empty struct as such. I'm inclined /not/ to test this case in the sample plugin, because this is meant as a "copy and paste" way to get started, and if you add a configuration, the test would fail.

Fixes  #17