### PR TITLE
Add make coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,14 @@ ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run fix;
 endif
 
+## Creates a coverage report for the server code.
+.PHONY: coverage
+coverage: server/.depensure webapp/.npminstall
+ifneq ($(HAS_SERVER),)
+	cd server && $(GO) test -race -coverprofile=coverage.txt ./...
+	@cd server && $(GO) tool cover -html=coverage.txt
+endif
+
 ## Clean removes all build artifacts.
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ endif
 .PHONY: test
 test: server/.depensure webapp/.npminstall
 ifneq ($(HAS_SERVER),)
-	cd server && $(GO) test -race -v -coverprofile=coverage.txt ./...
+	cd server && $(GO) test -race -v ./...
 endif
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run fix;


### PR DESCRIPTION
This PR adds a 'make coverage` command, which creates a coverage report for the server code.

The code isn't DRY but I don't know how to fix this without adding a new `test-server` target.

Is there a similar tool for webapp?