### PR TITLE
Start with version 0.1.0 instead of 0.0.1

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "com.mattermost.sample-plugin",
     "name": "Sample Plugin",
     "description": "This plugin serves as a starting point for writing a Mattermost plugin.",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,5 +5,5 @@ var manifest = struct {
 	Version string
 }{
 	Id:      "com.mattermost.sample-plugin",
-	Version: "0.0.1",
+	Version: "0.1.0",
 }

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
 export const id = 'com.mattermost.sample-plugin';
-export const version = '0.0.1';
+export const version = '0.1.0';


### PR DESCRIPTION
This is recommended by semver.org (See https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase)

It makes more clear that the first version is a minor version, **not** a patch version.  