### PR TITLE
changed single expression plugin upload to validate responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,10 +122,10 @@ ifneq ($(and $(MM_SERVICESETTINGS_SITEURL),$(MM_ADMIN_USERNAME),$(MM_ADMIN_PASSW
 	@echo "Installing plugin via API"
 	$(eval TOKEN := $(shell curl -i -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/users/login -d '{"login_id": "$(MM_ADMIN_USERNAME)", "password": "$(MM_ADMIN_PASSWORD)"}' | grep Token | cut -f2 -d' ' 2> /dev/null))
 	$(eval VERSION := $(shell curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins -F "plugin=@dist/$(BUNDLE_NAME)" -F "force=true" | grep -Po '"version": *\K"[^"]*"' | sed 's/\"//g'))
-	@if [ "$(VERSION)" != "$(PLUGIN_VERSION)" ]; then echo "There was a problem uploading the plugin."; exit 1; fi
+	@if [ "$(VERSION)" != "$(PLUGIN_VERSION)" ]; then echo "There was a problem uploading the plugin $(PLUGIN_VERSION) to $(PLUGIN_VERSION)."; exit 1; fi
 	$(eval STATUS := $(shell curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins/$(PLUGIN_ID)/enable | grep -Po '"status": *\K"[^"]*"' | sed 's/\"//g'))
 	@if [ "$(STATUS)" != "OK" ]; then echo "There was a problem enabling the plugin."; exit 1; fi
-	@echo "Ok."
+	@echo "OK."
 else ifneq ($(wildcard ../mattermost-server/.*),)
 	@echo "Installing plugin via filesystem. Server restart and manual plugin enabling required"
 	mkdir -p ../mattermost-server/plugins

--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,9 @@ deploy: dist
 ifneq ($(and $(MM_SERVICESETTINGS_SITEURL),$(MM_ADMIN_USERNAME),$(MM_ADMIN_PASSWORD),$(CURL)),)
 	@echo "Installing plugin via API"
 	$(eval TOKEN := $(shell curl -i --post301 --location $(MM_SERVICESETTINGS_SITEURL) -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/users/login -d '{"login_id": "$(MM_ADMIN_USERNAME)", "password": "$(MM_ADMIN_PASSWORD)"}' | grep Token | cut -f2 -d' ' 2> /dev/null))
-	$(eval VERSION := $(shell curl -s --post301 --location $(MM_SERVICESETTINGS_SITEURL) -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins -F "plugin=@dist/$(BUNDLE_NAME)" -F "force=true" | grep -Po '"version": *\K"[^"]*"' | sed 's/\"//g'))
-	@if [ "$(VERSION)" != "$(PLUGIN_VERSION)" ]; then echo "There was a problem uploading the plugin $(VERSION) to $(PLUGIN_VERSION)."; exit 1; fi
-	$(eval STATUS := $(shell curl -s --post301 --location $(MM_SERVICESETTINGS_SITEURL) -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins/$(PLUGIN_ID)/enable | grep -Po '"status": *\K"[^"]*"' | sed 's/\"//g'))
-	@if [ "$(STATUS)" != "OK" ]; then echo "There was a problem enabling the plugin."; exit 1; fi
-	@echo "OK."
+	@curl -s --post301 --location $(MM_SERVICESETTINGS_SITEURL) -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins -F "plugin=@dist/$(BUNDLE_NAME)" -F "force=true" > /dev/null && \
+		curl -s --post301 --location $(MM_SERVICESETTINGS_SITEURL) -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins/$(PLUGIN_ID)/enable > /dev/null && \
+		echo "OK." || echo "Sorry, something went wrong."
 else ifneq ($(wildcard ../mattermost-server/.*),)
 	@echo "Installing plugin via filesystem. Server restart and manual plugin enabling required"
 	mkdir -p ../mattermost-server/plugins

--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,10 @@ deploy: dist
 ## or copying the files directly to a sibling mattermost-server directory.
 ifneq ($(and $(MM_SERVICESETTINGS_SITEURL),$(MM_ADMIN_USERNAME),$(MM_ADMIN_PASSWORD),$(CURL)),)
 	@echo "Installing plugin via API"
-	$(eval TOKEN := $(shell curl -i -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/users/login -d '{"login_id": "$(MM_ADMIN_USERNAME)", "password": "$(MM_ADMIN_PASSWORD)"}' | grep Token | cut -f2 -d' ' 2> /dev/null))
-	$(eval VERSION := $(shell curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins -F "plugin=@dist/$(BUNDLE_NAME)" -F "force=true" | grep -Po '"version": *\K"[^"]*"' | sed 's/\"//g'))
+	$(eval TOKEN := $(shell curl -i --post301 --location $(MM_SERVICESETTINGS_SITEURL) -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/users/login -d '{"login_id": "$(MM_ADMIN_USERNAME)", "password": "$(MM_ADMIN_PASSWORD)"}' | grep Token | cut -f2 -d' ' 2> /dev/null))
+	$(eval VERSION := $(shell curl -s --post301 --location $(MM_SERVICESETTINGS_SITEURL) -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins -F "plugin=@dist/$(BUNDLE_NAME)" -F "force=true" | grep -Po '"version": *\K"[^"]*"' | sed 's/\"//g'))
 	@if [ "$(VERSION)" != "$(PLUGIN_VERSION)" ]; then echo "There was a problem uploading the plugin $(VERSION) to $(PLUGIN_VERSION)."; exit 1; fi
-	$(eval STATUS := $(shell curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins/$(PLUGIN_ID)/enable | grep -Po '"status": *\K"[^"]*"' | sed 's/\"//g'))
+	$(eval STATUS := $(shell curl -s --post301 --location $(MM_SERVICESETTINGS_SITEURL) -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins/$(PLUGIN_ID)/enable | grep -Po '"status": *\K"[^"]*"' | sed 's/\"//g'))
 	@if [ "$(STATUS)" != "OK" ]; then echo "There was a problem enabling the plugin."; exit 1; fi
 	@echo "OK."
 else ifneq ($(wildcard ../mattermost-server/.*),)

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ ifneq ($(and $(MM_SERVICESETTINGS_SITEURL),$(MM_ADMIN_USERNAME),$(MM_ADMIN_PASSW
 	@echo "Installing plugin via API"
 	$(eval TOKEN := $(shell curl -i -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/users/login -d '{"login_id": "$(MM_ADMIN_USERNAME)", "password": "$(MM_ADMIN_PASSWORD)"}' | grep Token | cut -f2 -d' ' 2> /dev/null))
 	$(eval VERSION := $(shell curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins -F "plugin=@dist/$(BUNDLE_NAME)" -F "force=true" | grep -Po '"version": *\K"[^"]*"' | sed 's/\"//g'))
-	@if [ "$(VERSION)" != "$(PLUGIN_VERSION)" ]; then echo "There was a problem uploading the plugin $(PLUGIN_VERSION) to $(PLUGIN_VERSION)."; exit 1; fi
+	@if [ "$(VERSION)" != "$(PLUGIN_VERSION)" ]; then echo "There was a problem uploading the plugin $(VERSION) to $(PLUGIN_VERSION)."; exit 1; fi
 	$(eval STATUS := $(shell curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins/$(PLUGIN_ID)/enable | grep -Po '"status": *\K"[^"]*"' | sed 's/\"//g'))
 	@if [ "$(STATUS)" != "OK" ]; then echo "There was a problem enabling the plugin."; exit 1; fi
 	@echo "OK."

--- a/Makefile
+++ b/Makefile
@@ -121,9 +121,11 @@ deploy: dist
 ifneq ($(and $(MM_SERVICESETTINGS_SITEURL),$(MM_ADMIN_USERNAME),$(MM_ADMIN_PASSWORD),$(CURL)),)
 	@echo "Installing plugin via API"
 	$(eval TOKEN := $(shell curl -i -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/users/login -d '{"login_id": "$(MM_ADMIN_USERNAME)", "password": "$(MM_ADMIN_PASSWORD)"}' | grep Token | cut -f2 -d' ' 2> /dev/null))
-	@curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins -F "plugin=@dist/$(BUNDLE_NAME)" -F "force=true" > /dev/null && \
-		curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins/$(PLUGIN_ID)/enable > /dev/null && \
-		echo "OK." || echo "Sorry, something went wrong."
+	$(eval VERSION := $(shell curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins -F "plugin=@dist/$(BUNDLE_NAME)" -F "force=true" | grep -Po '"version": *\K"[^"]*"' | sed 's/\"//g'))
+	@if [ "$(VERSION)" != "$(PLUGIN_VERSION)" ]; then echo "There was a problem uploading the plugin."; exit 1; fi
+	$(eval STATUS := $(shell curl -s -H "Authorization: Bearer $(TOKEN)" -X POST $(MM_SERVICESETTINGS_SITEURL)/api/v4/plugins/$(PLUGIN_ID)/enable | grep -Po '"status": *\K"[^"]*"' | sed 's/\"//g'))
+	@if [ "$(STATUS)" != "OK" ]; then echo "There was a problem enabling the plugin."; exit 1; fi
+	@echo "Ok."
 else ifneq ($(wildcard ../mattermost-server/.*),)
 	@echo "Installing plugin via filesystem. Server restart and manual plugin enabling required"
 	mkdir -p ../mattermost-server/plugins


### PR DESCRIPTION
Instead of individual calls '&&' together, the deploy now checks each response for a valid result.

This  fixes problems on Ubuntu 16.04 when mysteriously, the <upload> && <enable> && ok || failed never works.