### PR TITLE
Add support for custom makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ include build/setup.mk
 
 BUNDLE_NAME ?= $(PLUGIN_ID)-$(PLUGIN_VERSION).tar.gz
 
+ifneq ($(wildcard build/custom.mk),)
+	include build/custom.mk
+endif
+
 ## Checks the code style, tests, builds and bundles the plugin.
 all: check-style test dist
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ include build/setup.mk
 
 BUNDLE_NAME ?= $(PLUGIN_ID)-$(PLUGIN_VERSION).tar.gz
 
+# Include custom makefile, if pressent
 ifneq ($(wildcard build/custom.mk),)
 	include build/custom.mk
 endif

--- a/build/custom.mk
+++ b/build/custom.mk
@@ -1,0 +1,1 @@
+# Include custome targets and environment variables here


### PR DESCRIPTION
This PR adds support for custom makefiles. The custom makefile must be located under `build/custom.mk`. I don't see the need for making this customisable. I've added a empty file as a boiler plate.

Please note that custom targets will **not** be listed via `make help`. I tried fixing this but it took to much time. I would open a Help Wanted ticket for this, if there are no objections.